### PR TITLE
se elimina el boton de iniciar tramite que no se usaba

### DIFF
--- a/resources/views/layout/base.blade.php
+++ b/resources/views/layout/base.blade.php
@@ -153,11 +153,6 @@
 												<span class="menu-text m-0">Noticias</span>
 											</a>
 										</li> -->
-										<li class="menu-item">
-											<a href="#" class="menu-link">
-												<span class="menu-text m-0">Nuevo Trámite</span>
-											</a>
-										</li>
 									</ul>
 								</div>
 							    <form class="form-inline my-2 my-lg-0">


### PR DESCRIPTION
jose reporto un boton que no esta funcionando correctamente pero se decidió que era mejor eliminarlo 